### PR TITLE
Force an error to Sentry

### DIFF
--- a/tasks/safe_restart.rb
+++ b/tasks/safe_restart.rb
@@ -9,6 +9,12 @@ task :safe_restart, :environment do |_, args|
     abort 'An environment of "staging" or "production" must be specified'
   end
 
+  begin
+    1 / 0
+  rescue ZeroDivisionError => exception
+    Raven.capture_exception(exception)
+  end
+
   environment = args.fetch(:environment)
   environment = environment == 'production' ? 'wifi' : environment # very unfortunate
 

--- a/tasks/safe_restart.rb
+++ b/tasks/safe_restart.rb
@@ -4,6 +4,7 @@ require 'require_all'
 require_all 'lib'
 logger = Logger.new(STDOUT)
 
+# rubocop:disable Metrics/BlockLength
 task :safe_restart, :environment do |_, args|
   unless %w(staging production).include?(args['environment'])
     abort 'An environment of "staging" or "production" must be specified'
@@ -37,3 +38,4 @@ task :safe_restart, :environment do |_, args|
 
   p 'SAFE RESTARTING COMPLETED'
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Forces an error to sentry. Needs to be reverted and not pushed to production.