### PR TITLE
report on health check status as soon as one status is found to be unhealthy

### DIFF
--- a/lib/use_case/health_check.rb
+++ b/lib/use_case/health_check.rb
@@ -5,13 +5,10 @@ module UseCase
     end
 
     def healthy?
-      health_check_results = health_checks.map do |health_check|
-        unless noop_parent_health_check?(health_check)
-          status(route53_gateway.get_health_check_status(health_check_id: health_check.id))
-        end
+      health_checks.all? do |health_check|
+        return true if noop_parent_health_check?(health_check)
+        status(route53_gateway.get_health_check_status(health_check_id: health_check.id))
       end
-
-      health_check_results.compact.all?
     end
 
   private


### PR DESCRIPTION
This will reduce the amount of queries sent in the event of a status being found to be unhealthy