### PR TITLE
We are getting Throttled on Route53 health checks

### DIFF
--- a/lib/gateway/delayer.rb
+++ b/lib/gateway/delayer.rb
@@ -4,8 +4,8 @@ module Gateway
       @retries = 0
     end
 
-    def delay
-      sleep(WAIT_TIME)
+    def delay(wait_time: DEFAULT_WAIT_TIME)
+      sleep(wait_time)
     end
 
     def increment_retries
@@ -18,6 +18,6 @@ module Gateway
     end
 
     MAX_RETRIES = 10
-    WAIT_TIME = 150 # Cloudwatch health checks are 2 mins, 150 seconds is just over 2 mins
+    DEFAULT_WAIT_TIME = 150 # Cloudwatch health checks are 2 mins, 150 seconds is just over 2 mins
   end
 end

--- a/spec/use_case/health_check_spec.rb
+++ b/spec/use_case/health_check_spec.rb
@@ -103,9 +103,10 @@ end
 
 describe UseCase::HealthCheck do
   let(:aws_route53_gateway) { FakeHealthyRoute53Gateway.new }
+  let(:delayer) { spy('Gateway::Delayer', delay: nil) }
 
   let(:result) do
-    described_class.new(route53_gateway: aws_route53_gateway).healthy?
+    described_class.new(route53_gateway: aws_route53_gateway, delayer: delayer).healthy?
   end
 
   context 'Given health checkers are healthy' do
@@ -119,6 +120,13 @@ describe UseCase::HealthCheck do
 
     it 'returns an offline status' do
       expect(result).to eq(false)
+    end
+  end
+
+  context 'given a delayer' do
+    it 'delays the health checks to avoid throttling' do
+      described_class.new(route53_gateway: FakeHealthyRoute53Gateway.new, delayer: delayer).healthy?
+      expect(delayer).to have_received(:delay).twice.with(wait_time: 5)
     end
   end
 end


### PR DESCRIPTION
Slow these down by introducing a delay.
This should avoid the error we've been getting:

Aws::Route53::Errors::Throttling: Rate for operation GetHealthCheckStatus exceeded