### PR TITLE
Fix bug with initializing the health check use case

### DIFF
--- a/lib/use_case/health_check.rb
+++ b/lib/use_case/health_check.rb
@@ -1,6 +1,6 @@
 module UseCase
   class HealthCheck
-    def initialize(route53_gateway: Gateway::Aws::Route53.new, delayer: Gateway::Delayer.new(wait_time: 5))
+    def initialize(route53_gateway:, delayer:)
       @route53_gateway = route53_gateway
       @delayer = delayer
     end

--- a/tasks/safe_restart.rb
+++ b/tasks/safe_restart.rb
@@ -17,14 +17,13 @@ task :safe_restart, :environment do |_, args|
     ecs_gateway = Gateway::Aws::Ecs.new(config: { region: region })
     route53_gateway = Gateway::Aws::Route53.new
     cluster_finder = UseCase::FindClustersForEnvironment.new(gateway: ecs_gateway, environment: environment)
-    health_checker = UseCase::HealthCheck.new(route53_gateway: route53_gateway)
-    delayer = Gateway::Delayer.new
+    health_checker = UseCase::HealthCheck.new(route53_gateway: route53_gateway, delayer: Gateway::Delayer.new)
 
     UseCase::SafeRestart.new(
       cluster_finder: cluster_finder,
       ecs_gateway: ecs_gateway,
       health_checker: health_checker,
-      delayer: delayer,
+      delayer: Gateway::Delayer.new,
       logger: logger
     ).execute
   end


### PR DESCRIPTION
There is no need to use default arguments, explicitly initialize the HealthCheck
use case when needed