### PR TITLE
FIX - Replace deprecated govuk-lint-ruby for rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+# .rubocop.yml
+inherit_gem:
+  rubocop-govuk: 
+    - config/default.yml
+    - config/rails.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,15 @@
-source 'http://rubygems.org'
-ruby File.read('.ruby-version').chomp
+source "http://rubygems.org"
+ruby File.read(".ruby-version").chomp
 
-gem 'aws-sdk-ecs', '~> 1.43.0'
-gem 'aws-sdk-route53', '~> 1.25.0'
-gem 'multipart-post', '~> 2.1'
-gem 'rake', '~> 12.3.3'
-gem 'require_all', '~> 2.0'
-gem 'sentry-raven', '~> 2.9'
+gem "aws-sdk-ecs", "~> 1.43.0"
+gem "aws-sdk-route53", "~> 1.25.0"
+gem "multipart-post", "~> 2.1"
+gem "rake", "~> 12.3.3"
+gem "require_all", "~> 2.0"
+gem "sentry-raven", "~> 2.9"
 
 group :test do
-  gem 'govuk-lint'
-  gem 'pry'
-  gem 'rspec'
+  gem "pry"
+  gem "rspec"
+  gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,18 +21,12 @@ GEM
     diff-lcs (1.3)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.11.1)
-    govuk-lint (3.11.4)
-      rubocop (~> 0.72)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
-    jaro_winkler (1.5.3)
+    jaro_winkler (1.5.4)
     jmespath (1.4.0)
     method_source (0.9.2)
     multipart-post (2.1.1)
-    parallel (1.17.0)
-    parser (2.6.3.0)
+    parallel (1.19.1)
+    parser (2.7.0.2)
       ast (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -40,9 +34,6 @@ GEM
     rack (2.1.1)
     rainbow (3.0.0)
     rake (12.3.3)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     require_all (2.0.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -57,27 +48,23 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.72.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.1.0)
+    rubocop-govuk (2.0.0)
+      rubocop (= 0.77)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.4.1)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.33.0)
-      rubocop (>= 0.60.0)
+    rubocop-rspec (1.37.1)
+      rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.58.0)
-      rake (>= 0.9, < 13)
-      sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.9.0)
       faraday (>= 0.7.6, < 1.0)
     unicode-display_width (1.6.0)
@@ -88,16 +75,16 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-ecs (~> 1.43.0)
   aws-sdk-route53 (~> 1.25.0)
-  govuk-lint
   multipart-post (~> 2.1)
   pry
   rake (~> 12.3.3)
   require_all (~> 2.0)
   rspec
+  rubocop-govuk
   sentry-raven (~> 2.9)
 
 RUBY VERSION
    ruby 2.6.3
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ serve: build
 	$(DOCKER_COMPOSE) up -d
 
 lint: build
-	$(DOCKER_COMPOSE) run --rm app bundle exec govuk-lint-ruby
+	$(DOCKER_COMPOSE) run --rm app bundle exec rubocop
 
 test-rspec: serve
 	$(DOCKER_COMPOSE) run --rm app rspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
-require 'raven'
-require './tasks/safe_restart'
+require "raven"
+require "./tasks/safe_restart"
 
 Raven.configure do |config|
   config.environments = %w[production staging]
-  config.dsn = ENV['SENTRY_DSN']
+  config.dsn = ENV["SENTRY_DSN"]
 end

--- a/lib/gateway/aws/ecs.rb
+++ b/lib/gateway/aws/ecs.rb
@@ -5,7 +5,7 @@ module Gateway
         @client = ::Aws::ECS::Client.new(aws_config(config))
       end
 
-      def stop_task(cluster:, task:, reason: 'AUTOMATED RESTART')
+      def stop_task(cluster:, task:, reason: "AUTOMATED RESTART")
         client.stop_task(cluster: cluster, task: task, reason: reason)
       end
 
@@ -21,7 +21,7 @@ module Gateway
 
       attr_reader :client
 
-      DEFAULT_REGION = 'eu-west-2'.freeze
+      DEFAULT_REGION = "eu-west-2".freeze
 
       def aws_config(config)
         { region: DEFAULT_REGION }.merge(config)

--- a/lib/gateway/aws/route53.rb
+++ b/lib/gateway/aws/route53.rb
@@ -15,7 +15,7 @@ module Gateway
 
     private
 
-      DEFAULT_REGION = 'eu-west-2'.freeze
+      DEFAULT_REGION = "eu-west-2".freeze
 
       attr_reader :client
 

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,6 +1,6 @@
-require 'require_all'
+require "require_all"
 
-require 'aws-sdk-ecs'
-require 'aws-sdk-route53'
+require "aws-sdk-ecs"
+require "aws-sdk-route53"
 
-require_all 'lib'
+require_all "lib"

--- a/lib/use_case/health_check.rb
+++ b/lib/use_case/health_check.rb
@@ -18,7 +18,7 @@ module UseCase
 
     attr_reader :route53_gateway, :delayer
 
-    SUCCESS_STATUS = 'Success: HTTP Status Code 200, OK'.freeze
+    SUCCESS_STATUS = "Success: HTTP Status Code 200, OK".freeze
 
     def status(health_check)
       all_health_checkers_healthy?(health_check)

--- a/lib/use_case/safe_restart.rb
+++ b/lib/use_case/safe_restart.rb
@@ -10,7 +10,7 @@ module UseCase
 
     def execute
       unless health_checker.healthy?
-        raise 'Cannot Reboot Cluster, Health Checks failed'
+        raise "Cannot Reboot Cluster, Health Checks failed"
       end
 
       cluster_finder.execute.each do |cluster|
@@ -48,16 +48,16 @@ module UseCase
 
     def stop_task(cluster, task)
       p "Stopping task #{task} in cluster #{cluster}"
-      ecs_gateway.stop_task(cluster: cluster, task: task, reason: 'AUTOMATED RESTART')
+      ecs_gateway.stop_task(cluster: cluster, task: task, reason: "AUTOMATED RESTART")
     end
 
     def wait_or_timeout
       delayer.delay
-      p 'incrementing retries'
+      p "incrementing retries"
       delayer.increment_retries
 
       if delayer.max_retries_reached?
-        raise 'MAX RETRIES REACHED'
+        raise "MAX RETRIES REACHED"
       end
     end
 

--- a/spec/gateway/aws/ecs_spec.rb
+++ b/spec/gateway/aws/ecs_spec.rb
@@ -1,36 +1,36 @@
-require_relative '../../../lib/gateway/aws/ecs'
+require_relative "../../../lib/gateway/aws/ecs"
 
 describe Gateway::Aws::Ecs do
   subject { described_class.new(config: config) }
 
-  context 'clusters' do
+  context "clusters" do
     let(:config) do
       {
         stub_responses:
         {
-          list_clusters: double(cluster_arns: ['arn:aws:ecs:eu-west-2:123457:cluster/some-frontend-cluster'])
-        }
+          list_clusters: double(cluster_arns: ["arn:aws:ecs:eu-west-2:123457:cluster/some-frontend-cluster"]),
+        },
       }
     end
 
-    it 'returns a list of clusters' do
-      expect(subject.list_clusters).to eq(['arn:aws:ecs:eu-west-2:123457:cluster/some-frontend-cluster'])
+    it "returns a list of clusters" do
+      expect(subject.list_clusters).to eq(["arn:aws:ecs:eu-west-2:123457:cluster/some-frontend-cluster"])
     end
   end
 
-  context 'tasks' do
+  context "tasks" do
     let(:config) do
       {
         stub_responses:
         {
-          list_tasks: double(task_arns: ['arn:aws:ecs:eu-west-2:1234:task/xxxylyy3-bead-4d17-b6c2-f9bb0fc97c67'])
-        }
+          list_tasks: double(task_arns: ["arn:aws:ecs:eu-west-2:1234:task/xxxylyy3-bead-4d17-b6c2-f9bb0fc97c67"]),
+        },
       }
     end
 
-    it 'returns tasks belonging to the clusters' do
-      expect(subject.list_tasks(cluster: 'some-cluster')).to eq(
-        ['arn:aws:ecs:eu-west-2:1234:task/xxxylyy3-bead-4d17-b6c2-f9bb0fc97c67']
+    it "returns tasks belonging to the clusters" do
+      expect(subject.list_tasks(cluster: "some-cluster")).to eq(
+        ["arn:aws:ecs:eu-west-2:1234:task/xxxylyy3-bead-4d17-b6c2-f9bb0fc97c67"],
       )
     end
   end

--- a/spec/gateway/aws/route53_spec.rb
+++ b/spec/gateway/aws/route53_spec.rb
@@ -1,14 +1,14 @@
-require_relative '../../../lib/gateway/aws/route53'
+require_relative "../../../lib/gateway/aws/route53"
 
 describe Gateway::Aws::Route53 do
   let(:config) { { stub_responses: true } }
   subject { described_class.new(config: config) }
 
-  it '.list_health_checks' do
+  it ".list_health_checks" do
     expect(subject.list_health_checks.health_checks).to be_empty
   end
 
-  it '.get_health_check_status' do
-    expect(subject.get_health_check_status(health_check_id: 'abc').health_check_observations).to be_empty
+  it ".get_health_check_status" do
+    expect(subject.get_health_check_status(health_check_id: "abc").health_check_observations).to be_empty
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'rspec'
+require "rspec"
 
-ENV['RACK_ENV'] = 'test'
+ENV["RACK_ENV"] = "test"
 
-require File.expand_path('../lib/loader.rb', __dir__)
+require File.expand_path("../lib/loader.rb", __dir__)

--- a/spec/use_case/find_clusters_for_environment_spec.rb
+++ b/spec/use_case/find_clusters_for_environment_spec.rb
@@ -3,26 +3,26 @@ describe UseCase::FindClustersForEnvironment do
 
   let(:ecs_gateway) do
     double(list_clusters: [
-      'arn:aws:ecs:eu-west-2:abc123:cluster/staging-frontend-cluster',
-      'arn:aws:ecs:eu-west-2:abc123:cluster/wifi-frontend-cluster',
-      'arn:aws:ecs:eu-west-2:abc123:cluster/staging-some-other-cluster',
-      'arn:aws:ecs:eu-west-2:abc123:cluster/wifi-some-other-cluster'
+      "arn:aws:ecs:eu-west-2:abc123:cluster/staging-frontend-cluster",
+      "arn:aws:ecs:eu-west-2:abc123:cluster/wifi-frontend-cluster",
+      "arn:aws:ecs:eu-west-2:abc123:cluster/staging-some-other-cluster",
+      "arn:aws:ecs:eu-west-2:abc123:cluster/wifi-some-other-cluster",
     ])
   end
 
-  context 'given Staging' do
-    let(:environment) { 'staging' }
+  context "given Staging" do
+    let(:environment) { "staging" }
 
-    it 'finds only staging clusters' do
-      expect(subject.execute).to eq(['arn:aws:ecs:eu-west-2:abc123:cluster/staging-frontend-cluster'])
+    it "finds only staging clusters" do
+      expect(subject.execute).to eq(["arn:aws:ecs:eu-west-2:abc123:cluster/staging-frontend-cluster"])
     end
   end
 
-  context 'given Production' do
-    let(:environment) { 'wifi' }
+  context "given Production" do
+    let(:environment) { "wifi" }
 
-    it 'finds only production clusters' do
-      expect(subject.execute).to eq(['arn:aws:ecs:eu-west-2:abc123:cluster/wifi-frontend-cluster'])
+    it "finds only production clusters" do
+      expect(subject.execute).to eq(["arn:aws:ecs:eu-west-2:abc123:cluster/wifi-frontend-cluster"])
     end
   end
 end

--- a/spec/use_case/health_check_spec.rb
+++ b/spec/use_case/health_check_spec.rb
@@ -5,17 +5,17 @@ class FakeHealthyRoute53Gateway
     client.stub_responses(:get_health_check_status, health_check_observations:
     [
       {
-        region: 'ap-southeast-2',
-        ip_address: '39.239.222.111',
+        region: "ap-southeast-2",
+        ip_address: "39.239.222.111",
         status_report: {
-          status: 'Success: HTTP Status Code 200, OK'
-        }
+          status: "Success: HTTP Status Code 200, OK",
+        },
       }, {
-        region: 'ap-eu-west-1',
-        ip_address: '27.111.39.33',
+        region: "ap-eu-west-1",
+        ip_address: "27.111.39.33",
         status_report: {
-          status: 'Success: HTTP Status Code 200, OK'
-        }
+          status: "Success: HTTP Status Code 200, OK",
+        },
       }
     ])
 
@@ -27,29 +27,29 @@ class FakeHealthyRoute53Gateway
       stub_responses: {
         list_health_checks: {
           max_items: 10,
-          marker: 'PageMarker',
+          marker: "PageMarker",
           is_truncated: false,
           health_checks: [
             {
-              caller_reference: 'AdminMonitoring',
-              id: 'abc123',
+              caller_reference: "AdminMonitoring",
+              id: "abc123",
               health_check_version: 1,
               health_check_config: {
                 measure_latency: false,
-                type: 'HTTP',
-              }
+                type: "HTTP",
+              },
             }, {
-              caller_reference: 'AdminMonitoring',
-              id: 'xyz789',
+              caller_reference: "AdminMonitoring",
+              id: "xyz789",
               health_check_version: 1,
               health_check_config: {
                 measure_latency: false,
-                type: 'HTTP',
-              }
+                type: "HTTP",
+              },
             }
-          ]
-        }
-      }
+          ],
+        },
+      },
     )
 
     client.list_health_checks
@@ -63,12 +63,12 @@ class FakeUnHealthyRoute53Gateway
     client.stub_responses(:get_health_check_status, health_check_observations:
       [
         {
-          region: 'ap-southeast-2',
-          ip_address: '39.239.222.111',
+          region: "ap-southeast-2",
+          ip_address: "39.239.222.111",
           status_report: {
-            status: 'Failure: HTTP Status Code 500, Host Unreachable'
-          }
-        }
+            status: "Failure: HTTP Status Code 500, Host Unreachable",
+          },
+        },
       ])
 
     client.get_health_check_status(health_check_id: health_check_id)
@@ -79,22 +79,22 @@ class FakeUnHealthyRoute53Gateway
       stub_responses: {
         list_health_checks: {
           max_items: 10,
-          marker: 'PageMarker',
+          marker: "PageMarker",
           is_truncated: false,
           health_checks: [
             {
-              caller_reference: 'AdminMonitoring',
-              id: 'latency123',
+              caller_reference: "AdminMonitoring",
+              id: "latency123",
               health_check_version: 1,
               health_check_config: {
-                ip_address: '123.123.123.123',
+                ip_address: "123.123.123.123",
                 measure_latency: false,
-                type: 'HTTP',
-              }
-            }
-          ]
-        }
-      }
+                type: "HTTP",
+              },
+            },
+          ],
+        },
+      },
     )
 
     client.list_health_checks
@@ -103,28 +103,28 @@ end
 
 describe UseCase::HealthCheck do
   let(:aws_route53_gateway) { FakeHealthyRoute53Gateway.new }
-  let(:delayer) { spy('Gateway::Delayer', delay: nil) }
+  let(:delayer) { spy("Gateway::Delayer", delay: nil) }
 
   let(:result) do
     described_class.new(route53_gateway: aws_route53_gateway, delayer: delayer).healthy?
   end
 
-  context 'Given health checkers are healthy' do
-    it 'returns operational if all health checkers are healthy' do
+  context "Given health checkers are healthy" do
+    it "returns operational if all health checkers are healthy" do
       expect(result).to eq(true)
     end
   end
 
-  context 'Given some checkers are unhealthy' do
+  context "Given some checkers are unhealthy" do
     let(:aws_route53_gateway) { FakeUnHealthyRoute53Gateway.new }
 
-    it 'returns an offline status' do
+    it "returns an offline status" do
       expect(result).to eq(false)
     end
   end
 
-  context 'given a delayer' do
-    it 'delays the health checks to avoid throttling' do
+  context "given a delayer" do
+    it "delays the health checks to avoid throttling" do
       described_class.new(route53_gateway: FakeHealthyRoute53Gateway.new, delayer: delayer).healthy?
       expect(delayer).to have_received(:delay).twice.with(wait_time: 5)
     end

--- a/tasks/safe_restart.rb
+++ b/tasks/safe_restart.rb
@@ -1,16 +1,16 @@
-require 'logger'
+require "logger"
 
-require 'require_all'
-require_all 'lib'
+require "require_all"
+require_all "lib"
 logger = Logger.new(STDOUT)
 
 task :safe_restart, :environment do |_, args|
-  unless %w(staging production).include?(args['environment'])
+  unless %w(staging production).include?(args["environment"])
     abort 'An environment of "staging" or "production" must be specified'
   end
 
   environment = args.fetch(:environment)
-  environment = environment == 'production' ? 'wifi' : environment # very unfortunate
+  environment = environment == "production" ? "wifi" : environment # very unfortunate
 
   %w(eu-west-2 eu-west-1).each do |region|
     p "== SAFE RESTARTING #{region} =="
@@ -24,9 +24,9 @@ task :safe_restart, :environment do |_, args|
       ecs_gateway: ecs_gateway,
       health_checker: health_checker,
       delayer: Gateway::Delayer.new,
-      logger: logger
+      logger: logger,
     ).execute
   end
 
-  p 'SAFE RESTARTING COMPLETED'
+  p "SAFE RESTARTING COMPLETED"
 end


### PR DESCRIPTION
See https://docs.publishing.service.gov.uk/manual/migrate-from-govuk-lint.html

Just ' -> " changes needed