### PR TITLE
BAU - allow manual trigger of PR jobs

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -95,7 +95,7 @@ jobs:
   - name: lint & test
     interruptible: true
     # force people to use new git commits to rerun PRs
-    disable_manual_trigger: true
+    disable_manual_trigger: false
     plan:
       - aggregate:
         - do:


### PR DESCRIPTION
Occasionally a concourse PR build job will fail for reasons unrelated with the PR itself (network timeout, for example). This means we usually need to do a workaround of force pushing an "empty" commit to re-trigger the job.
This PR allows for concourse jobs to be triggered via the concourse GUI or via fly.

Signed-off-by: Paula Valenca <paula.valenca@digital.cabinet-office.gov.uk>