### PR TITLE
Revert "BAU - allow manual trigger of PR jobs"

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -95,7 +95,7 @@ jobs:
   - name: lint & test
     interruptible: true
     # force people to use new git commits to rerun PRs
-    disable_manual_trigger: false
+    disable_manual_trigger: true
     plan:
       - aggregate:
         - do:


### PR DESCRIPTION
Reverts alphagov/govwifi-safe-restarter#103

This will trigger the latest build, which is not what we want.
The desired functionality has been implemented on version 6.0 of concourse, so we can revisit this then

Reference: https://github.com/concourse/concourse/issues/413