### PR TITLE
BAU: remove Rails from rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,4 +2,3 @@
 inherit_gem:
   rubocop-govuk: 
     - config/default.yml
-    - config/rails.yml


### PR DESCRIPTION
This isn't a Rails project.  Later versions of Rubocop are trying to enforce erroneous cops due to this misconfiguration.

Merging this should resolve the issue blocking https://github.com/alphagov/govwifi-safe-restarter/pull/157 from being merged.