### PR TITLE
Increase Waiting Time Before Retries

### DIFF
--- a/lib/gateway/delayer.rb
+++ b/lib/gateway/delayer.rb
@@ -18,6 +18,6 @@ module Gateway
     end
 
     MAX_RETRIES = 10
-    DEFAULT_WAIT_TIME = 150 # Cloudwatch health checks are 2 mins, 150 seconds is just over 2 mins
+    DEFAULT_WAIT_TIME = 300 # Cloudwatch health checks are 2 mins, 300 seconds is 5 mins
   end
 end


### PR DESCRIPTION
We have added some extra components to the containers, as a result
it appears that they are now taking longer to spin up. We are
increasing the retry wait time accordingly.

Additions made to the containers can be seen here:
https://github.com/alphagov/govwifi-frontend/pull/112/files