### PR TITLE
Increase Waiting Time Before Retries To 10 Minutes

### DIFF
--- a/lib/gateway/delayer.rb
+++ b/lib/gateway/delayer.rb
@@ -18,6 +18,6 @@ module Gateway
     end
 
     MAX_RETRIES = 10
-    DEFAULT_WAIT_TIME = 300 # Cloudwatch health checks are 2 mins, 300 seconds is 5 mins
+    DEFAULT_WAIT_TIME = 600 # Cloudwatch health checks are 2 mins, 600 seconds is 10 mins
   end
 end


### PR DESCRIPTION
Containers are taking longer than usual to spin up. Increasing
wait time while we are investigating.