### PR TITLE
reduce max-retries from 10 to 5 following investigation

### DIFF
--- a/lib/gateway/delayer.rb
+++ b/lib/gateway/delayer.rb
@@ -17,7 +17,7 @@ module Gateway
       @retries >= MAX_RETRIES
     end
 
-    MAX_RETRIES = 10
+    MAX_RETRIES = 5
     DEFAULT_WAIT_TIME = 900 # 900 seconds is 15 mins. Currently docker containers are taking 11+ minutes to spawn
   end
 end


### PR DESCRIPTION
### What
Reduce max retries before escalating to an alert, from 10 to 5
Note: Time out before retry is currently 15 minutes.

### Why
Investigating in the logs, shows the maximum number of retries over the past 3 months = 3.
With the limit at 10 retries of 15 minutes each, it would be 2h 15m before we knew something was wrong (say at retry 4) and before we begin to address the issue. Setting this to 5 results in a much quicker response to an out of bounds restart process.

### Note
The time out value of 15 minutes appears correct at this time as limited docker 'pulls' are possible during restart and the subsequent process can take 11 minutes or slightly more. So no adjustment is required to the time out value.

### Testing
As per README.md
Requires docker.

make lint
make test

