### PR TITLE
Use the builtin set_pipeline in ci/pipelines/pr.yml

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -15,11 +15,6 @@ resource_types:
     password: ((docker_hub_authtoken))
 
 resources:
-  - name: tech-ops
-    type: git
-    source:
-      uri: https://github.com/alphagov/tech-ops.git
-
   - name: govwifi-safe-restarter
     type: git
     source:
@@ -82,19 +77,10 @@ jobs:
   - name: self-update
     serial: true
     plan:
-    - get: tech-ops
-      params:
-        submodules: none
     - get: govwifi-safe-restarter
       trigger: true
-    - task: set-pipelines
-      file: tech-ops/ci/tasks/self-updating-pipeline.yaml
-      input_mapping: {repository: govwifi-safe-restarter}
-      params:
-        CONCOURSE_TEAM: govwifi
-        CONCOURSE_PASSWORD: ((readonly_local_user_password))
-        PIPELINE_PATH: ci/pipelines/pr.yml
-        PIPELINE_NAME: safe-restarter-pr
+    - set_pipeline: safe-restarter-pr
+      file: govwifi-safe-restarter/ci/pipelines/pr.yml
 
   - name: lint & test
     interruptible: true


### PR DESCRIPTION
### What
Use the builtin set_pipeline in ci/pipelines/pr.yml

### Why
This avoids using the deprecated tech-ops task, and works better with
the GovWifi Concourse.

