### PR TITLE
Add xml gem following Sentry alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ gem "aws-sdk-route53", "~> 1.60.0"
 gem "multipart-post", "~> 2.1"
 gem "rake", "~> 13.0.6"
 gem "require_all", "~> 3.0"
-gem "sentry-raven", "~> 3.1"
 gem "rexml", "~> 3.2"
+gem "sentry-raven", "~> 3.1"
 
 group :test do
   gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "multipart-post", "~> 2.1"
 gem "rake", "~> 13.0.6"
 gem "require_all", "~> 3.0"
 gem "sentry-raven", "~> 3.1"
+gem "rexml", "~> 3.2"
 
 group :test do
   gem "pry"


### PR DESCRIPTION
### What

Add `rexml` gem to Gemfile.

### Why

* [Sentry is reporting a RunTimeError](https://sentry.io/organizations/government-digital-services/issues/2948798069/?project=1398533&referrer=slack): `Unable to find a compatible xml library. Ensure that you have installed or added to your Gemfile one of ox, oga, libxml, nokogiri or rexml` originating from `aws-sdk-core`.
* According to [research](https://stackoverflow.com/questions/69258788/aws-sdk-core-xml-parser-rb74in-set-default-engine-unable-to-find-a-compatib), adding one of the XML libraries mentioned will resolve this error.
* The Gemfile.lock already contains a reference to `rexml` which is why I chose it over `nokogiri` (a gem used elsewhere in our Ruby codebases). 

**I'm unable to reproduce the error locally so feel a bit wary about implementing this fix. A review or chat with a Ruby developer would be appreciated.**
