### PR TITLE
Improve safe restarter retry logic

### DIFF
--- a/lib/gateway/delayer.rb
+++ b/lib/gateway/delayer.rb
@@ -17,6 +17,10 @@ module Gateway
       @retries >= MAX_RETRIES
     end
 
+    def reset
+      @retries = 0
+    end
+
     MAX_RETRIES = 5
     DEFAULT_WAIT_TIME = 900 # 900 seconds is 15 mins. Currently docker containers are taking 11+ minutes to spawn
   end

--- a/lib/use_case/safe_restart.rb
+++ b/lib/use_case/safe_restart.rb
@@ -39,6 +39,10 @@ module UseCase
 
     def restart_and_wait_for(task, original_tasks, cluster)
       stop_task(cluster, task)
+
+      # Give the new task a chance to start before checking the count
+      delayer.delay
+
       wait_or_timeout until original_tasks.count == cluster_tasks(cluster).count
     end
 

--- a/lib/use_case/safe_restart.rb
+++ b/lib/use_case/safe_restart.rb
@@ -15,6 +15,8 @@ module UseCase
 
       cluster_finder.execute.each do |cluster|
         rolling_restart_cluster(cluster)
+
+        delayer.reset
       end
     end
 

--- a/spec/use_case/safe_restart_spec.rb
+++ b/spec/use_case/safe_restart_spec.rb
@@ -16,6 +16,10 @@ class DelayerFake
   def max_retries_reached?
     @retries > health_check_retry_limit
   end
+
+  def reset
+    @retries = 0
+  end
 end
 
 class EventuallyHealthyHealthCheckFake


### PR DESCRIPTION
### What
Improve safe restarter retry logic

### Why
So that it hopefully copes with the addition of the Fargate clusters.

