### PR TITLE
Speed up safe restarting

### DIFF
--- a/lib/gateway/delayer.rb
+++ b/lib/gateway/delayer.rb
@@ -21,7 +21,7 @@ module Gateway
       @retries = 0
     end
 
-    MAX_RETRIES = 5
-    DEFAULT_WAIT_TIME = 900 # 900 seconds is 15 mins. Currently docker containers are taking 11+ minutes to spawn
+    MAX_RETRIES = 15
+    DEFAULT_WAIT_TIME = 300 # 5 mins.
   end
 end


### PR DESCRIPTION
### What
Drop the default wait time and increase the max retries accordingly.

### Why
This should make the safe restarter faster by having it detect when
changes have happened more quickly.

