### PR TITLE
Just restart tasks in the new frontend-fargate cluster

### DIFF
--- a/lib/use_case/find_clusters_for_environment.rb
+++ b/lib/use_case/find_clusters_for_environment.rb
@@ -7,10 +7,7 @@ module UseCase
 
     def execute
       ecs_gateway.list_clusters.select do |cluster_arn|
-        # TODO: This can be updated once the migration to Fargate for
-        # Frontend is completed
-        cluster_arn.match?(/#{environment}-frontend/) ||
-          cluster_arn.match?(/frontend-fargate/)
+        cluster_arn.match?(/frontend-fargate/)
       end
     end
 

--- a/spec/use_case/find_clusters_for_environment_spec.rb
+++ b/spec/use_case/find_clusters_for_environment_spec.rb
@@ -3,10 +3,8 @@ describe UseCase::FindClustersForEnvironment do
 
   let(:ecs_gateway) do
     double(list_clusters: [
-      "arn:aws:ecs:eu-west-2:abc123:cluster/staging-frontend-cluster",
-      "arn:aws:ecs:eu-west-2:abc123:cluster/wifi-frontend-cluster",
-      "arn:aws:ecs:eu-west-2:abc123:cluster/staging-some-other-cluster",
-      "arn:aws:ecs:eu-west-2:abc123:cluster/wifi-some-other-cluster",
+      "arn:aws:ecs:eu-west-2:abc123:cluster/frontend-fargate",
+      "arn:aws:ecs:eu-west-2:abc123:cluster/other-cluster",
     ])
   end
 
@@ -14,7 +12,7 @@ describe UseCase::FindClustersForEnvironment do
     let(:environment) { "staging" }
 
     it "finds only staging clusters" do
-      expect(subject.execute).to eq(["arn:aws:ecs:eu-west-2:abc123:cluster/staging-frontend-cluster"])
+      expect(subject.execute).to eq(["arn:aws:ecs:eu-west-2:abc123:cluster/frontend-fargate"])
     end
   end
 
@@ -22,7 +20,7 @@ describe UseCase::FindClustersForEnvironment do
     let(:environment) { "wifi" }
 
     it "finds only production clusters" do
-      expect(subject.execute).to eq(["arn:aws:ecs:eu-west-2:abc123:cluster/wifi-frontend-cluster"])
+      expect(subject.execute).to eq(["arn:aws:ecs:eu-west-2:abc123:cluster/frontend-fargate"])
     end
   end
 end


### PR DESCRIPTION
### What
Just restart tasks in the new frontend-fargate cluster

### Why
The migration to the Network Load Balancer and new cluster for
frontend is now nearing completion, so only the new cluster tasks need
restarting.


