### PR TITLE
Remove Route 53 Healthchecks From Safe Restarter

### DIFF
--- a/lib/use_case/safe_restart.rb
+++ b/lib/use_case/safe_restart.rb
@@ -9,9 +9,9 @@ module UseCase
     end
 
     def execute
-      unless health_checker.healthy?
-        raise "Cannot Reboot Cluster, Health Checks failed"
-      end
+      # unless health_checker.healthy?
+      #   raise "Cannot Reboot Cluster, Health Checks failed"
+      # end
 
       cluster_finder.execute.each do |cluster|
         rolling_restart_cluster(cluster)
@@ -30,7 +30,7 @@ module UseCase
       p "Canary is: #{canary}"
       p "Rest is: #{rest}"
       restart_and_wait_for(canary, tasks, cluster)
-      wait_or_timeout until health_checker.healthy?
+      # wait_or_timeout until health_checker.healthy?
 
       p "Moving onto the rest"
       rest.each do |task|


### PR DESCRIPTION
### What
Remove Route 53 Healthchecks From Safe Restarter

### Why
The Route53 healthchecks were useful when our radius servers were running on EC2. Now that they are behind and loadbalancer and running on ECS fargate the route53 healthchecks are no longer used. These should have been removed from the code when we migrated the radius servers to fargate.


